### PR TITLE
SSLZ-3481_adjust-ruby-line-length-rubocop

### DIFF
--- a/panolint-ruby-rubocop.yml
+++ b/panolint-ruby-rubocop.yml
@@ -27,7 +27,7 @@ Layout/LineContinuationSpacing:
   EnforcedStyle: no_space
 
 Layout/LineLength:
-  Max: 80
+  Max: 120
   IgnoreCopDirectives: true
 
 Lint/AmbiguousBlockAssociation:


### PR DESCRIPTION
Increase rubocop's line length warning from 80 to 120