### PR TITLE
SECZ-2495: Require CodeQL compatible syntax

### DIFF
--- a/panolint-ruby-rubocop.yml
+++ b/panolint-ruby-rubocop.yml
@@ -74,6 +74,10 @@ Metrics/PerceivedComplexity:
 Naming/BinaryOperatorParameterName:
   Enabled: false
 
+# CodeQL cannot parse anonymous block parameters
+Naming/BlockForwarding:
+  EnforcedStyle: explicit
+
 Naming/FileName:
   Exclude:
     - .overcommit/Gemfile
@@ -105,6 +109,10 @@ RSpec/NestedGroups:
 Style/Alias:
   Enabled: true
   EnforcedStyle: prefer_alias_method
+
+# CodeQL cannot parse anonymous block parameters
+Style/ArgumentsForwarding:
+  UseAnonymousForwarding: false
 
 Style/ArrayCoercion:
   Enabled: true


### PR DESCRIPTION
Github Advance Security's CodeQL does not correctly parse anonymous block forwarding, so any file with that syntax will fail to be parsed.

This PR requires explicit naming for block forwarding, so that our code scanning will work correct.

Example output when trying to fix the syntax:
```
<path>: C: [Correctable] Naming/BlockForwarding: Use anonymous block forwarding.
<path>: C: [Correctable] Style/ArgumentsForwarding: Use anonymous block arguments forwarding (`&`).
```

Docs:
* [Naming/BlockForwarding](https://docs.rubocop.org/rubocop/cops_naming.html#namingblockforwarding)
* [Style/ArgumentsForwarding](https://docs.rubocop.org/rubocop/cops_style.html#styleargumentsforwarding)