### PR TITLE
SECZ-2701: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-prs.yml
+++ b/.github/workflows/dependabot-prs.yml
@@ -1,4 +1,7 @@
 name: Dependabot Pull Request
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: Main
 on: push
+permissions:
+  contents: read
 jobs:
   ci:
     name: CI


### PR DESCRIPTION
Potential fix for [https://github.com/panorama-ed/panolint-ruby/security/code-scanning/1](https://github.com/panorama-ed/panolint-ruby/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow performs basic CI tasks (checking out code, setting up Ruby, and running RuboCop), it only requires `contents: read` permissions. This block should be added at the root level of the workflow to apply to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
