### PR TITLE
CIIZ-3437 Always enforce shorthand hash/keyword arg syntax

### DIFF
--- a/panolint-ruby-rubocop.yml
+++ b/panolint-ruby-rubocop.yml
@@ -139,7 +139,7 @@ Style/HashAsLastArrayItem:
   Enabled: true
 
 Style/HashSyntax:
-  EnforcedShorthandSyntax: either
+  EnforcedShorthandSyntax: always
 
 Style/MixinUsage:
   Exclude:


### PR DESCRIPTION
This commit changes our `Style/HashSyntax` cop setting to `EnforcedShorthandSyntax: always`, changing `{ foo: foo }` and `bar(foo: foo)` to `{ foo: }` and `bar(foo:)`. This provides several benefits:

1. Many multi-line statements can now become one-liners
2. It encourages more consistent variable naming
3. Syntax highlighting (depending on configuration) can make it clearer when arguments do not share the same name

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it may trigger widespread RuboCop offenses and auto-corrections across consuming Ruby projects.
> 
> **Overview**
> Updates `Style/HashSyntax` to set `EnforcedShorthandSyntax: always`, requiring shorthand `{ foo: }` / `bar(foo:)` instead of `{ foo: foo }` / `bar(foo: foo)` in projects inheriting this RuboCop config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdc6058238a0410a18b6aa44e93112eef4a82faa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->