### PR TITLE
SECOPS-523: Update dependabot bake time, and gem file bake time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
 - package-ecosystem: bundler
   directory: "/"
+  cooldown:
+    default-days: 7
   schedule:
     interval: weekly
     time: "00:00"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 6
 
 gemspec


### PR DESCRIPTION
Update Dependabot bake time, and gem file bake time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk dependency automation/configuration change; it does not modify application runtime logic.
> 
> **Overview**
> Adds a 7-day Dependabot cooldown for Bundler updates in `.github/dependabot.yml` so dependency PRs wait before opening.
> 
> Also adds a `cooldown: 6` option to the RubyGems source in `Gemfile`, aligning dependency bake-time behavior for gem resolution/configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96298cbb11b34ad7e2a71734bd77a1cc50626196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->